### PR TITLE
feat: allow initilize/dispose multiple times for same IrisMethodChannel object

### DIFF
--- a/lib/src/iris_method_channel.dart
+++ b/lib/src/iris_method_channel.dart
@@ -303,15 +303,15 @@ class IrisMethodChannel {
   IrisMethodChannel();
 
   bool _initilized = false;
-  late final _Messenger messenger;
-  late final StreamSubscription evntSubscription;
+  late _Messenger messenger;
+  late StreamSubscription evntSubscription;
   @visibleForTesting
   final ScopedObjects scopedEventHandlers = ScopedObjects();
-  late final int _nativeHandle;
+  late int _nativeHandle;
 
   @visibleForTesting
-  late final Isolate workerIsolate;
-  late final _HotRestartFinalizer _hotRestartFinalizer;
+  late Isolate workerIsolate;
+  late _HotRestartFinalizer _hotRestartFinalizer;
 
   static Future<void> _execute(_InitilizationArgs args) async {
     SendPort mainApiCallSendPort = args.apiCallPortSendPort;

--- a/test/iris_method_channel_test.dart
+++ b/test/iris_method_channel_test.dart
@@ -239,6 +239,35 @@ void main() {
         _FakeNativeBindingDelegateProvider(nativeBindingDelegate, irisEvent);
   });
 
+  test(
+      'able to initilize/dispose multiple times for same IrisMethodChannel object',
+      () async {
+    final irisMethodChannel = IrisMethodChannel();
+    await irisMethodChannel.initilize(nativeBindingsProvider);
+    final callApiResult1 = await irisMethodChannel
+        .invokeMethod(const IrisMethodCall('a_func_name', 'params'));
+    expect(callApiResult1.irisReturnCode, 0);
+    expect(callApiResult1.data, {});
+
+    final callRecord1 = messenger.callApiRecords
+        .where((e) => e.methodCall.funcName == 'a_func_name');
+    expect(callRecord1.length, 1);
+
+    await irisMethodChannel.dispose();
+
+    await irisMethodChannel.initilize(nativeBindingsProvider);
+    final callApiResult2 = await irisMethodChannel
+        .invokeMethod(const IrisMethodCall('a_func_name2', 'params'));
+    expect(callApiResult2.irisReturnCode, 0);
+    expect(callApiResult2.data, {});
+
+    final callRecord2 = messenger.callApiRecords
+        .where((e) => e.methodCall.funcName == 'a_func_name2');
+    expect(callRecord2.length, 1);
+
+    await irisMethodChannel.dispose();
+  });
+
   test('invokeMethod', () async {
     final irisMethodChannel = IrisMethodChannel();
     await irisMethodChannel.initilize(nativeBindingsProvider);


### PR DESCRIPTION
This implementation allows the `IrisMethodChannel` more easily to controll by a singleton class.