### PR TITLE
Initialize IrisEvent and register send port first in _IrisMethodChannelNative.initilize

### DIFF
--- a/lib/src/iris_method_channel.dart
+++ b/lib/src/iris_method_channel.dart
@@ -722,13 +722,12 @@ class _IrisMethodChannelNative {
   CreateNativeApiEngineResult initilize(
       SendPort sendPort, List<ffi.Pointer<ffi.Void>> args) {
     _irisEvent.initialize();
-    _nativeIrisApiEngineBinding.initialize();
+    _irisEvent.registerEventHandler(sendPort);
 
+    _nativeIrisApiEngineBinding.initialize();
     final createResult =
         _nativeIrisApiEngineBinding.createNativeApiEngine(args);
     _irisApiEnginePtr = createResult.apiEnginePtr;
-
-    _irisEvent.registerEventHandler(sendPort);
 
     _irisCEventHandler = calloc<iris.IrisCEventHandler>()
       ..ref.OnEvent = _irisEvent.onEventPtr.cast();


### PR DESCRIPTION
We call `addObserverForName` in C++ inside the `IrisEvent.registerEventHandler` in iOS/macOS, at this time, the `IrisEvent.registerEventHandler`  is called after the `createNativeApiEngine `, if an `addObserverForName` is called inside the `createNativeApiEngine `, which may block our observer. To ensure our observer always calls first, so move `IrisEvent.registerEventHandler` above the `_nativeIrisApiEngineBinding.initialize()`.