### PR TITLE
fix: [android] Bound the IrisMethodChannel lifecycle with the FlutterEngine

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -205,9 +205,9 @@ jobs:
         with:
           flutter-version: '3.10.0' # Run the latest version
           cache: true
-      - uses: futureware-tech/simulator-action@v1
+      - uses: futureware-tech/simulator-action@v2
         with:
-          model: 'iPhone 13 Pro Max'
+          model: 'iPhone 14 Pro Max'
       - name: ios integration test
         run: |
           flutter packages get

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,7 +197,7 @@ jobs:
   integration_test_ios:
     name: ios integration test
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v1

--- a/android/src/main/java/com/agora/iris_method_channel/IrisMethodChannelPlugin.java
+++ b/android/src/main/java/com/agora/iris_method_channel/IrisMethodChannelPlugin.java
@@ -24,15 +24,13 @@ public class IrisMethodChannelPlugin implements FlutterPlugin, MethodCallHandler
 
   @Override
   public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
-    if (call.method.equals("getPlatformVersion")) {
-      result.success("Android " + android.os.Build.VERSION.RELEASE);
-    } else {
-      result.notImplemented();
-    }
+    result.notImplemented();
   }
 
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    // Notify the dart side to call the `IrisMethodChannel.dispose` to clear the resources.
+    channel.invokeMethod("onDetachedFromEngine_fromPlatform",  null);
     channel.setMethodCallHandler(null);
   }
 }

--- a/lib/src/iris_method_channel.dart
+++ b/lib/src/iris_method_channel.dart
@@ -5,7 +5,7 @@ import 'dart:isolate';
 import 'package:async/async.dart';
 import 'package:ffi/ffi.dart';
 import 'package:flutter/foundation.dart'
-    show SynchronousFuture, VoidCallback, visibleForTesting;
+    show SynchronousFuture, VoidCallback, debugPrint, visibleForTesting;
 import 'package:flutter/services.dart';
 import 'package:iris_method_channel/src/bindings/native_iris_api_common_bindings.dart'
     as iris;
@@ -406,6 +406,7 @@ class IrisMethodChannel {
   void _setuponDetachedFromEngineListener() {
     _channel.setMethodCallHandler((call) async {
       if (call.method == 'onDetachedFromEngine_fromPlatform') {
+        debugPrint('Receive the onDetachedFromEngine callback, clean the native resources.');
         dispose();
         return true;
       }

--- a/lib/src/iris_method_channel.dart
+++ b/lib/src/iris_method_channel.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:ffi' as ffi;
 import 'dart:isolate';
-import 'dart:typed_data';
 
 import 'package:async/async.dart';
 import 'package:ffi/ffi.dart';

--- a/lib/src/iris_method_channel.dart
+++ b/lib/src/iris_method_channel.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
 import 'dart:ffi' as ffi;
 import 'dart:isolate';
+import 'dart:typed_data';
 
 import 'package:async/async.dart';
 import 'package:ffi/ffi.dart';
 import 'package:flutter/foundation.dart'
     show SynchronousFuture, VoidCallback, debugPrint, visibleForTesting;
-import 'package:flutter/services.dart';
+import 'package:flutter/services.dart' show MethodChannel;
 import 'package:iris_method_channel/src/bindings/native_iris_api_common_bindings.dart'
     as iris;
 import 'package:iris_method_channel/src/iris_event.dart';

--- a/test/iris_method_channel_test.dart
+++ b/test/iris_method_channel_test.dart
@@ -228,8 +228,7 @@ class _TestEventLoopEventHandler extends EventLoopEventHandler {
 }
 
 void main() {
-  final TestWidgetsFlutterBinding binding =
-      TestWidgetsFlutterBinding.ensureInitialized();
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
 
   late _FakeNativeBindingDelegateMessenger messenger;
   late NativeBindingsProvider nativeBindingsProvider;

--- a/test/iris_method_channel_test.dart
+++ b/test/iris_method_channel_test.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:ffi' as ffi;
 import 'dart:isolate';
-import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
 import 'package:flutter/services.dart';

--- a/test/iris_method_channel_test.dart
+++ b/test/iris_method_channel_test.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 import 'dart:ffi' as ffi;
 import 'dart:isolate';
+import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
-import 'package:flutter/services.dart';
+import 'package:flutter/services.dart' show StandardMethodCodec, MethodCall;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:iris_method_channel/src/bindings/native_iris_api_common_bindings.dart';
 import 'package:iris_method_channel/src/bindings/native_iris_event_bindings.dart'

--- a/test/iris_method_channel_test.dart
+++ b/test/iris_method_channel_test.dart
@@ -452,8 +452,8 @@ void main() {
   test('disposed after receive onDetachedFromEngine_fromPlatform', () async {
     await irisMethodChannel.initilize([]);
 
+    // Simulate the `MethodChannel` call from native side
     const StandardMethodCodec codec = StandardMethodCodec();
-
     final ByteData data = codec.encodeMethodCall(const MethodCall(
       'onDetachedFromEngine_fromPlatform',
     ));

--- a/test/iris_method_channel_test.dart
+++ b/test/iris_method_channel_test.dart
@@ -4,6 +4,8 @@ import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:iris_method_channel/src/bindings/native_iris_api_common_bindings.dart';
 import 'package:iris_method_channel/src/bindings/native_iris_event_bindings.dart'
     as iris_event;
@@ -11,7 +13,6 @@ import 'package:iris_method_channel/src/iris_event.dart';
 import 'package:iris_method_channel/src/iris_method_channel.dart';
 import 'package:iris_method_channel/src/native_bindings_delegate.dart';
 import 'package:iris_method_channel/src/scoped_objects.dart';
-import 'package:test/test.dart';
 
 class _ApiParam {
   _ApiParam(this.event, this.data);
@@ -227,6 +228,9 @@ class _TestEventLoopEventHandler extends EventLoopEventHandler {
 }
 
 void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
   late _FakeNativeBindingDelegateMessenger messenger;
   late NativeBindingsProvider nativeBindingsProvider;
   late IrisMethodChannel irisMethodChannel;
@@ -414,6 +418,61 @@ void main() {
     expect(registerEventHandlerCallRecord.length, 1);
 
     await irisMethodChannel.dispose();
+  });
+
+  test('disposed', () async {
+    await irisMethodChannel.initilize([]);
+    await irisMethodChannel.dispose();
+    // Wait for `dispose` completed.
+    await Future.delayed(const Duration(milliseconds: 500));
+    final callRecord1 = messenger.callApiRecords
+        .where((e) => e.methodCall.funcName == 'destroyNativeApiEngine');
+    expect(callRecord1.length, 1);
+
+    final callRecord2 = messenger.callApiRecords
+        .where((e) => e.methodCall.funcName == 'destroyIrisEventHandler');
+    expect(callRecord2.length, 1);
+  });
+
+  test('disposed multiple times', () async {
+    await irisMethodChannel.initilize([]);
+    await irisMethodChannel.dispose();
+    await irisMethodChannel.dispose();
+    // Wait for `dispose` completed.
+    await Future.delayed(const Duration(milliseconds: 500));
+    final callRecord1 = messenger.callApiRecords
+        .where((e) => e.methodCall.funcName == 'destroyNativeApiEngine');
+    expect(callRecord1.length, 1);
+
+    final callRecord2 = messenger.callApiRecords
+        .where((e) => e.methodCall.funcName == 'destroyIrisEventHandler');
+    expect(callRecord2.length, 1);
+  });
+
+  test('disposed after receive onDetachedFromEngine_fromPlatform', () async {
+    await irisMethodChannel.initilize([]);
+
+    const StandardMethodCodec codec = StandardMethodCodec();
+
+    final ByteData data = codec.encodeMethodCall(const MethodCall(
+      'onDetachedFromEngine_fromPlatform',
+    ));
+    await binding.defaultBinaryMessenger.handlePlatformMessage(
+      'iris_method_channel',
+      data,
+      (ByteData? data) {},
+    );
+
+    // Wait for the `iris_method_channel` method channel call completed.
+    await Future.delayed(const Duration(milliseconds: 1000));
+
+    final callRecord1 = messenger.callApiRecords
+        .where((e) => e.methodCall.funcName == 'destroyNativeApiEngine');
+    expect(callRecord1.length, 1);
+
+    final callRecord2 = messenger.callApiRecords
+        .where((e) => e.methodCall.funcName == 'destroyIrisEventHandler');
+    expect(callRecord2.length, 1);
   });
 
   test('invokeMethod after disposed', () async {


### PR DESCRIPTION
At this time, if the `IrisMethodChannel.dispose` not be called explicitly, the native resources created (created via `NativeBindingDelegate.createNativeApiEngine`) by the `IrisMethodChannel` can not be cleaned. So the native resources only be cleaned when the APP process is killed. 

But by default, the `FlutterEngine` lifecycle is bound to the android `Activity` lifecycle. In the single Flutter APP, the `FlutterEngine` is killed when the whole APP exit(the `Activity.onDestory` has been called), at this time, the whole APP exit, and the APP process has been killed, so the native resources created by the `IrisMethodChannel` can be cleaned depending on the process lifecycle.

But in some scenarios, say that start a foreground service in android, when you try to remove the APP from the recent list, the `Activity` has been removed, the `FlutterEngine` has been destroyed, but the APP still running (the process not be killed), which will cause the memory leak, and unexpected behavior. 

So we need to notify the `IrisMethodChannel`(dart side) to clean the native resources when the `FlutterEngine` is destroyed.
