### PR TITLE
fix: [android] Add namespace to work with android gradle 8.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.agora.iris_method_channel'
+    }
+
     compileSdkVersion 31
 
     externalNativeBuild {


### PR DESCRIPTION
Fix https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/issues/81