### PR TITLE
fix: Wait for the executor.dispose done before exit the isolate

### DIFF
--- a/test/iris_method_channel_test.dart
+++ b/test/iris_method_channel_test.dart
@@ -209,8 +209,6 @@ void main() {
   test('disposed', () async {
     await irisMethodChannel.initilize([]);
     await irisMethodChannel.dispose();
-    // Wait for `dispose` completed.
-    await Future.delayed(const Duration(milliseconds: 500));
     final callRecord1 = messenger.callApiRecords
         .where((e) => e.methodCall.funcName == 'destroyNativeApiEngine');
     expect(callRecord1.length, 1);
@@ -227,8 +225,6 @@ void main() {
     await irisMethodChannel.initilize([]);
     await irisMethodChannel.dispose();
     await irisMethodChannel.dispose();
-    // Wait for `dispose` completed.
-    await Future.delayed(const Duration(milliseconds: 500));
     final callRecord1 = messenger.callApiRecords
         .where((e) => e.methodCall.funcName == 'destroyNativeApiEngine');
     expect(callRecord1.length, 1);


### PR DESCRIPTION
We send a `null` to the sub isolate the clean up the native resources(`destroyNativeApiEngine`...), but we do not wait for the clean-up logic to be finished, which will cause an error if we want to clean up something relative to the native resources right after the `dispose` function in sychronize way.  For example the test cases from the `agora_rtc_engine`  https://github.com/AgoraIO-Extensions/Agora-Flutter-SDK/blob/main/test_shard/fake_test_app/integration_test/apis_call_fake_test.dart
```dart
  testWidgets(
    'AudioDeviceManager.enumeratePlaybackDevices',
    (WidgetTester tester) async {
      ...
      await rtcEngine.release();
    },
  );

  tearDown(() {
    setMockRtcEngineProvider(null);
    // It's not safe to dispose here, since the `executor.dispose` inside the isolate may run after this dispose function.
    irisTester!.dispose(); 
    irisTester = null;
  });


```