### PR TITLE
fix: Prevent creation of multiple isolates when IrisMethodChannel.initialize is called multiple times simultaneously

### DIFF
--- a/lib/src/iris_method_channel.dart
+++ b/lib/src/iris_method_channel.dart
@@ -10,16 +10,20 @@ import 'package:iris_method_channel/src/platform/iris_method_channel_internal.da
 
 class CallOnce {
   Completer<void> _completer = Completer<void>();
+  bool _isRunning = false;
 
   Future<void> callOnce(Future<void> Function() func) async {
-    if (!_completer.isCompleted) {
+    if (!_completer.isCompleted && !_isRunning) {
       try {
+        _isRunning = true;
         await func();
       } catch (e) {
         _completer = Completer<void>();
+        _isRunning = false;
         rethrow;
       }
       _completer.complete();
+      _isRunning = false;
     }
     return _completer.future;
   }

--- a/lib/src/platform/io/iris_method_channel_internal_io.dart
+++ b/lib/src/platform/io/iris_method_channel_internal_io.dart
@@ -408,6 +408,8 @@ class IrisMethodChannelInternalIO implements IrisMethodChannelInternal {
   late Isolate workerIsolate;
   late _HotRestartFinalizer _hotRestartFinalizer;
 
+  CallOnce? _initializeCallOnce;
+
   static Future<void> _execute(_InitilizationArgs args) async {
     final SendPort mainApiCallSendPort = args.apiCallPortSendPort;
     final SendPort mainEventSendPort = args.eventPortSendPort;
@@ -507,62 +509,59 @@ class IrisMethodChannelInternalIO implements IrisMethodChannelInternal {
       return null;
     }
 
-    final apiCallPort = ReceivePort();
-    final eventPort = ReceivePort();
+    late InitilizationResultIO initilizationResult;
+    _initializeCallOnce ??= CallOnce();
+    await _initializeCallOnce!.callOnce(() async {
+      final apiCallPort = ReceivePort();
+      final eventPort = ReceivePort();
 
-    _hotRestartFinalizer = _HotRestartFinalizer(_nativeBindingsProvider);
+      _hotRestartFinalizer = _HotRestartFinalizer(_nativeBindingsProvider);
 
-    workerIsolate = await Isolate.spawn(
-      _execute,
-      _InitilizationArgs(
-        apiCallPort.sendPort,
-        eventPort.sendPort,
-        _hotRestartFinalizer.onExitSendPort,
-        _nativeBindingsProvider,
-        args,
-      ),
-      onExit: _hotRestartFinalizer.onExitSendPort,
-    );
+      workerIsolate = await Isolate.spawn(
+        _execute,
+        _InitilizationArgs(
+          apiCallPort.sendPort,
+          eventPort.sendPort,
+          _hotRestartFinalizer.onExitSendPort,
+          _nativeBindingsProvider,
+          args,
+        ),
+        onExit: _hotRestartFinalizer.onExitSendPort,
+      );
 
-    // Convert the ReceivePort into a StreamQueue to receive messages from the
-    // spawned isolate using a pull-based interface. Events are stored in this
-    // queue until they are accessed by `events.next`.
-    // final events = StreamQueue<dynamic>(p);
-    final responseQueue = StreamQueue<dynamic>(apiCallPort);
+      final responseQueue = StreamQueue<dynamic>(apiCallPort);
 
-    // The first message from the spawned isolate is a SendPort. This port is
-    // used to communicate with the spawned isolate.
-    // SendPort sendPort = await events.next;
-    final msg = await responseQueue.next;
-    assert(msg is InitilizationResult);
-    final initilizationResult = msg as InitilizationResultIO;
-    final requestPort = initilizationResult._apiCallPortSendPort;
-    _nativeHandle = initilizationResult.irisApiEngineNativeHandle;
+      final msg = await responseQueue.next;
+      assert(msg is InitilizationResult);
+      initilizationResult = msg as InitilizationResultIO;
+      final requestPort = initilizationResult._apiCallPortSendPort;
+      _nativeHandle = initilizationResult.irisApiEngineNativeHandle;
 
-    assert(() {
-      _hotRestartFinalizer.debugIrisApiEngineNativeHandle =
-          initilizationResult.irisApiEngineNativeHandle;
-      _hotRestartFinalizer.debugIrisCEventHandlerNativeHandle =
-          initilizationResult._debugIrisCEventHandlerNativeHandle;
-      _hotRestartFinalizer.debugIrisEventHandlerNativeHandle =
-          initilizationResult._debugIrisEventHandlerNativeHandle;
+      assert(() {
+        _hotRestartFinalizer.debugIrisApiEngineNativeHandle =
+            initilizationResult.irisApiEngineNativeHandle;
+        _hotRestartFinalizer.debugIrisCEventHandlerNativeHandle =
+            initilizationResult._debugIrisCEventHandlerNativeHandle;
+        _hotRestartFinalizer.debugIrisEventHandlerNativeHandle =
+            initilizationResult._debugIrisEventHandlerNativeHandle;
 
-      return true;
-    }());
+        return true;
+      }());
 
-    _messenger = _Messenger(requestPort, responseQueue);
+      _messenger = _Messenger(requestPort, responseQueue);
 
-    _evntSubscription = eventPort.listen((message) {
-      if (!_initilized) {
-        return;
-      }
+      _evntSubscription = eventPort.listen((message) {
+        if (!_initilized) {
+          return;
+        }
 
-      final eventMessage = parseMessage(message);
+        final eventMessage = parseMessage(message);
 
-      _irisEventMessageListener?.call(eventMessage);
+        _irisEventMessageListener?.call(eventMessage);
+      });
+
+      _initilized = true;
     });
-
-    _initilized = true;
 
     return initilizationResult;
   }
@@ -576,8 +575,8 @@ class IrisMethodChannelInternalIO implements IrisMethodChannelInternal {
     _irisEventMessageListener = null;
     _hotRestartFinalizer.dispose();
     await _evntSubscription.cancel();
-
     await _messenger.dispose();
+    _initializeCallOnce = null;
   }
 
   @override

--- a/lib/src/platform/io/iris_method_channel_internal_io.dart
+++ b/lib/src/platform/io/iris_method_channel_internal_io.dart
@@ -408,7 +408,7 @@ class IrisMethodChannelInternalIO implements IrisMethodChannelInternal {
   late Isolate workerIsolate;
   late _HotRestartFinalizer _hotRestartFinalizer;
 
-  CallOnce? _initializeCallOnce;
+  AsyncMemoizer? _initializeCallOnce;
 
   static Future<void> _execute(_InitilizationArgs args) async {
     final SendPort mainApiCallSendPort = args.apiCallPortSendPort;
@@ -510,8 +510,8 @@ class IrisMethodChannelInternalIO implements IrisMethodChannelInternal {
     }
 
     late InitilizationResultIO initilizationResult;
-    _initializeCallOnce ??= CallOnce();
-    await _initializeCallOnce!.callOnce(() async {
+    _initializeCallOnce ??= AsyncMemoizer();
+    await _initializeCallOnce!.runOnce(() async {
       final apiCallPort = ReceivePort();
       final eventPort = ReceivePort();
 

--- a/test/iris_method_channel_test.dart
+++ b/test/iris_method_channel_test.dart
@@ -71,6 +71,36 @@ void main() {
     await irisMethodChannel.dispose();
   });
 
+  test('only initialize once', () async {
+    await irisMethodChannel.initilize([]);
+    await irisMethodChannel.initilize([]);
+    await irisMethodChannel.initilize([]);
+
+    final callRecord1 = messenger.callApiRecords
+        .where((e) => e.methodCall.funcName == 'createApiEngine');
+    expect(callRecord1.length, 1);
+
+    await irisMethodChannel.dispose();
+  });
+
+  test('can re-initialize after dispose', () async {
+    await irisMethodChannel.initilize([]);
+    await irisMethodChannel.initilize([]);
+    await irisMethodChannel.initilize([]);
+    await irisMethodChannel.dispose();
+    final callRecord1 = messenger.callApiRecords
+        .where((e) => e.methodCall.funcName == 'createApiEngine');
+    expect(callRecord1.length, 1);
+
+    await irisMethodChannel.initilize([]);
+    await irisMethodChannel.initilize([]);
+    await irisMethodChannel.initilize([]);
+    final callRecord2 = messenger.callApiRecords
+        .where((e) => e.methodCall.funcName == 'createApiEngine');
+    expect(callRecord2.length, 2);
+    await irisMethodChannel.dispose();
+  });
+
   test('invokeMethod', () async {
     await irisMethodChannel.initilize([]);
     final callApiResult = await irisMethodChannel

--- a/test/iris_method_channel_test.dart
+++ b/test/iris_method_channel_test.dart
@@ -83,6 +83,19 @@ void main() {
     await irisMethodChannel.dispose();
   });
 
+  test('only initialize once when called simultaneously', () async {
+    for (int i = 0; i < 5; ++i) {
+      irisMethodChannel.initilize([]);
+    }
+    // Wait for the 5 times calls of `irisMethodChannel.initilize` are completed.
+    await Future.delayed(const Duration(milliseconds: 1000));
+    final callRecord1 = messenger.callApiRecords
+        .where((e) => e.methodCall.funcName == 'createApiEngine');
+    expect(callRecord1.length, 1);
+
+    await irisMethodChannel.dispose();
+  });
+
   test('can re-initialize after dispose', () async {
     await irisMethodChannel.initilize([]);
     await irisMethodChannel.initilize([]);

--- a/test/platform/fake/fake_platform_binding_delegate_io.dart
+++ b/test/platform/fake/fake_platform_binding_delegate_io.dart
@@ -102,6 +102,15 @@ class FakeNativeBindingDelegate extends PlatformBindingsDelegateInterface {
         ),
       );
       apiCallPortSendPort.send(record);
+    } else {
+      final record = CallApiRecord(
+        const IrisMethodCall('createApiEngine', '{}'),
+        CallApiRecordApiParam(
+          'createApiEngine',
+          '{}',
+        ),
+      );
+      apiCallPortSendPort.send(record);
     }
     return CreateApiEngineResult(
       engineHandle,


### PR DESCRIPTION
A case like:
```dart
for (int i = 0; i < 5; ++i) {
  irisMethodChannel.initilize([]);
}
```
If we do not guard the initialization only once, multiple isolates will be created.