### PR TITLE
feat: Add throwExceptionHandler

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -242,7 +242,7 @@ jobs:
   integration_test_ios:
     name: ios integration test
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v1
@@ -264,7 +264,7 @@ jobs:
   integration_test_ios_use_frameworks:
     name: ios integration test with use_frameworks
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v1

--- a/lib/src/iris_method_channel.dart
+++ b/lib/src/iris_method_channel.dart
@@ -9,6 +9,19 @@ import 'package:iris_method_channel/src/platform/iris_method_channel_internal.da
 
 // ignore_for_file: public_member_api_docs
 
+@pragma('vm:prefer-inline')
+ThrowExceptionHandler throwException = _defaultThrowExceptionBuilder;
+@pragma('vm:prefer-inline')
+void _defaultThrowExceptionBuilder({required int code, String? message}) {
+  throw Exception();
+}
+
+typedef ExceptionBuilder = Exception Function(
+    {required int code, String? message});
+
+typedef ThrowExceptionHandler = void Function(
+    {required int code, String? message});
+
 class IrisMethodChannel {
   IrisMethodChannel(this._nativeBindingsProvider) {
     _irisMethodChannelInternal =

--- a/lib/src/iris_method_channel.dart
+++ b/lib/src/iris_method_channel.dart
@@ -10,14 +10,11 @@ import 'package:iris_method_channel/src/platform/iris_method_channel_internal.da
 // ignore_for_file: public_member_api_docs
 
 @pragma('vm:prefer-inline')
-ThrowExceptionHandler throwException = _defaultThrowExceptionBuilder;
+ThrowExceptionHandler throwExceptionHandler = _defaultThrowExceptionHandler;
 @pragma('vm:prefer-inline')
-void _defaultThrowExceptionBuilder({required int code, String? message}) {
+void _defaultThrowExceptionHandler({required int code, String? message}) {
   throw Exception();
 }
-
-typedef ExceptionBuilder = Exception Function(
-    {required int code, String? message});
 
 typedef ThrowExceptionHandler = void Function(
     {required int code, String? message});

--- a/test/iris_method_channel_test.dart
+++ b/test/iris_method_channel_test.dart
@@ -867,4 +867,32 @@ void main() {
       await irisMethodChannel.dispose();
     },
   );
+
+  test(
+    'throwExceptionHandler throw Exception by default',
+    () async {
+      final currentThrowExceptionHandler = throwExceptionHandler;
+
+      expect(() => throwExceptionHandler(code: 1, message: 'message'),
+          throwsA(isA<Exception>()));
+
+      throwExceptionHandler = currentThrowExceptionHandler;
+    },
+  );
+
+  test(
+    'Can override throwExceptionHandler',
+    () async {
+      final currentThrowExceptionHandler = throwExceptionHandler;
+
+      throwExceptionHandler = ({required int code, String? message}) {
+        throw StateError('message');
+      };
+
+      expect(() => throwExceptionHandler(code: 1, message: 'message'),
+          throwsA(isA<StateError>()));
+
+      throwExceptionHandler = currentThrowExceptionHandler;
+    },
+  );
 }


### PR DESCRIPTION
Add `throwExceptionHandler ` to allow us to reuse the same throw exception method in the package, rather than call `throw Exception` directly.