### PR TITLE
[ci] Fix CI failed caused by using an unsupported NodeJS version

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,9 +24,6 @@ jobs:
         with:
           ref: ${{ inputs.release_branch }}
           fetch-depth: 0
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Install release-it
         run: |
           npm install -g release-it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,6 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
       - name: Install release-it
         run: |
           npm install -g release-it


### PR DESCRIPTION
We now use the system default NodeJS.

Fix failed job: https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/actions/runs/11253132109/job/31487048517

Referred: https://github.com/octokit/octokit.js/?tab=readme-ov-file#fetch-missing