### PR TITLE
🐛 Copy the result data instead of referencing directly

### DIFF
--- a/lib/src/platform/iris_method_channel_interface.dart
+++ b/lib/src/platform/iris_method_channel_interface.dart
@@ -18,11 +18,13 @@ class BufferParam {
 }
 
 class CallApiResult {
-  CallApiResult(
-      {required this.irisReturnCode, required this.data, this.rawData = ''});
+  CallApiResult({
+    required this.irisReturnCode,
+    required Map<String, dynamic> data,
+    this.rawData = '',
+  }) : data = Map<String, dynamic>.from(data);
 
   final int irisReturnCode;
-
   final Map<String, dynamic> data;
 
   // TODO(littlegnal): Remove rawData after EP-253 landed.

--- a/lib/src/platform/iris_method_channel_interface.dart
+++ b/lib/src/platform/iris_method_channel_interface.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
-import 'package:flutter/foundation.dart' show VoidCallback, SynchronousFuture;
+import 'package:flutter/foundation.dart'
+    show VoidCallback, SynchronousFuture, immutable;
 import 'package:iris_method_channel/src/iris_handles.dart';
 import 'package:iris_method_channel/src/platform/iris_event_interface.dart';
 import 'package:iris_method_channel/src/scoped_objects.dart';
@@ -17,12 +18,25 @@ class BufferParam {
   final int length;
 }
 
+@immutable
 class CallApiResult {
-  CallApiResult({
-    required this.irisReturnCode,
+  factory CallApiResult({
     required Map<String, dynamic> data,
+    required int irisReturnCode,
+    String rawData = '',
+  }) {
+    return CallApiResult._(
+      data: Map<String, dynamic>.from(data),
+      irisReturnCode: irisReturnCode,
+      rawData: rawData,
+    );
+  }
+
+  const CallApiResult._({
+    required this.irisReturnCode,
+    required this.data,
     this.rawData = '',
-  }) : data = Map<String, dynamic>.from(data);
+  });
 
   final int irisReturnCode;
   final Map<String, dynamic> data;


### PR DESCRIPTION
When a const map was delivered in the call result, modifying the data would be unsupported since the data is unmodifiable.

https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/blob/418b5d4e6c60212c9edae73d6c89219c99902eb9/lib/src/platform/io/iris_method_channel_internal_io.dart#L374

The above line might throw:
```console
Unhandled Exception: Unsupported operation: Cannot modify unmodifiable map
```