### PR TITLE
fix(android): update compileSdkVersion from 31 to 34 for API 34 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ android {
         namespace 'com.agora.iris_method_channel'
     }
 
-    compileSdkVersion safeExtGet('compileSdkVersion', 31)
+    compileSdkVersion safeExtGet('compileSdkVersion', 34)
 
     externalNativeBuild {
         cmake {


### PR DESCRIPTION
- Resolves build failures with Android API 34+ dependencies
- Fixes checkDebugAarMetadata task failures for iris_method_channel
- Ensures compatibility with androidx dependencies requiring API 34+
- Addresses issues with androidx.fragment, androidx.window, and other dependencies

Fixes: Build failures when using iris_method_channel with Android API 34+