### PR TITLE
chore: sync OHOS branch with 2.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.2.4](https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/compare/2.2.3...2.2.4) (2025-07-24)
+
+### Bug Fixes
+
+* prefix exported Iris symbols to avoid collisions ([#122](https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/issues/122)) ([292ce32](https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/commit/292ce32edaaf8ad8db9706a7c8bfc7d6ec4f613a))
+
 ## [2.2.3](https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/compare/2.2.2...2.2.3) (2025-06-25)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.2.5](https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/compare/2.2.4...2.2.5) (2026-04-13)
+
+### Bug Fixes
+
+* avoid concurrent modification during event dispatch ([#128](https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/issues/128)) ([b275c0f](https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/commit/b275c0fa1ddde27906817caf2dfeaece292f176d))
+
 ## [2.2.4](https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/compare/2.2.3...2.2.4) (2025-07-24)
 
 ### Bug Fixes

--- a/ios/iris_method_channel/Sources/iris_method_channel/IrisMethodChannelPlugin.m
+++ b/ios/iris_method_channel/Sources/iris_method_channel/IrisMethodChannelPlugin.m
@@ -21,11 +21,11 @@
 /// dummy function to avoid symbols striping when building static library.
 + (void)_irisMethodChannelDummyFunc {
   EventParam p;
-	InitDartApiDL(NULL);
-  Dispose();
-  OnEvent(NULL);
-  RegisterDartPort(0);
-  UnregisterDartPort(0);
+	Iris_InitDartApiDL(NULL);
+  Iris_Dispose();
+  Iris_OnEvent(NULL);
+  Iris_RegisterDartPort(0);
+  Iris_UnregisterDartPort(0);
 }
 
 @end

--- a/lib/src/iris_method_channel.dart
+++ b/lib/src/iris_method_channel.dart
@@ -2,7 +2,14 @@ import 'dart:async';
 
 import 'package:async/async.dart' show AsyncMemoizer;
 import 'package:flutter/foundation.dart'
-    show VoidCallback, debugPrint, visibleForTesting;
+    show
+        VoidCallback,
+        debugPrint,
+        visibleForTesting,
+        FlutterError,
+        FlutterErrorDetails,
+        ErrorDescription,
+        kDebugMode;
 import 'package:flutter/services.dart' show MethodChannel;
 import 'package:iris_method_channel/iris_method_channel.dart';
 import 'package:iris_method_channel/src/platform/iris_method_channel_internal.dart';
@@ -64,29 +71,46 @@ class IrisMethodChannel {
       initilizationResult = await _irisMethodChannelInternal.initilize(args);
 
       _irisMethodChannelInternal.setIrisEventMessageListener((eventMessage) {
-        bool handled = false;
-        for (final sub in scopedEventHandlers.values) {
-          final scopedObjects = sub as DisposableScopedObjects;
-          for (final es in scopedObjects.values) {
-            final EventHandlerHolder eh = es as EventHandlerHolder;
-            // We need the event handlers with the same _EventHandlerHolderKey consume the message.
-            for (final e in eh.getEventHandlers()) {
-              if (e.handleEvent(eventMessage.event, eventMessage.data,
-                  eventMessage.buffers)) {
-                handled = true;
+        try {
+          bool handled = false;
+          for (final sub in scopedEventHandlers.values) {
+            final scopedObjects = sub as DisposableScopedObjects;
+            for (final es in scopedObjects.values) {
+              final EventHandlerHolder eh = es as EventHandlerHolder;
+              // We need the event handlers with the same _EventHandlerHolderKey consume the message.
+              final handlersSnapshot = eh.getEventHandlers();
+
+              for (final e in handlersSnapshot.toList()) {
+                if (!eh.getEventHandlers().contains(e)) {
+                  continue;
+                }
+                if (e.handleEvent(eventMessage.event, eventMessage.data,
+                    eventMessage.buffers)) {
+                  handled = true;
+                }
+              }
+
+              // Break the loop after the event handlers in the same EventHandlerHolder
+              // consume the message.
+              if (handled) {
+                break;
               }
             }
 
-            // Break the loop after the event handlers in the same EventHandlerHolder
-            // consume the message.
+            // Break the loop if there is an EventHandlerHolder consume the message.
             if (handled) {
               break;
             }
           }
-
-          // Break the loop if there is an EventHandlerHolder consume the message.
-          if (handled) {
-            break;
+        } catch (e, s) {
+          FlutterError.reportError(FlutterErrorDetails(
+            exception: e,
+            stack: s,
+            library: 'iris_method_channel',
+            context: ErrorDescription('IrisMethodChannel handleEvent'),
+          ));
+          if (kDebugMode) {
+            rethrow;
           }
         }
       });

--- a/lib/src/platform/io/bindings/native_iris_event_bindings.dart
+++ b/lib/src/platform/io/bindings/native_iris_event_bindings.dart
@@ -31,7 +31,7 @@ class NativeIrisEventBinding {
 
   late final _InitDartApiDLPtr =
       _lookup<ffi.NativeFunction<ffi.IntPtr Function(ffi.Pointer<ffi.Void>)>>(
-          'InitDartApiDL');
+          'Iris_InitDartApiDL');
   late final _InitDartApiDL =
       _InitDartApiDLPtr.asFunction<int Function(ffi.Pointer<ffi.Void>)>();
 
@@ -40,7 +40,7 @@ class NativeIrisEventBinding {
   }
 
   late final _DisposePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function()>>('Dispose');
+      _lookup<ffi.NativeFunction<ffi.Void Function()>>('Iris_Dispose');
   late final _Dispose = _DisposePtr.asFunction<void Function()>();
 
   void OnEvent(
@@ -53,7 +53,7 @@ class NativeIrisEventBinding {
 
   late final _OnEventPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<EventParam>)>>(
-          'OnEvent');
+          'Iris_OnEvent');
   late final _OnEvent =
       _OnEventPtr.asFunction<void Function(ffi.Pointer<EventParam>)>();
 
@@ -131,7 +131,7 @@ class NativeIrisEventBinding {
 
   late final _RegisterDartPortPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'RegisterDartPort');
+          'Iris_RegisterDartPort');
   late final _RegisterDartPort =
       _RegisterDartPortPtr.asFunction<void Function(int)>();
 
@@ -145,7 +145,7 @@ class NativeIrisEventBinding {
 
   late final _UnregisterDartPortPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
-          'UnregisterDartPort');
+          'Iris_UnregisterDartPort');
   late final _UnregisterDartPort =
       _UnregisterDartPortPtr.asFunction<void Function(int)>();
 

--- a/lib/src/platform/iris_method_channel_interface.dart
+++ b/lib/src/platform/iris_method_channel_interface.dart
@@ -186,8 +186,9 @@ class EventHandlerHolder
     _eventHandlers.add(eventHandler);
   }
 
-  Future<void> removeEventHandler(EventLoopEventHandler eventHandler) async {
+  Future<void> removeEventHandler(EventLoopEventHandler eventHandler) {
     _eventHandlers.remove(eventHandler);
+    return SynchronousFuture(null);
   }
 
   Set<EventLoopEventHandler> getEventHandlers() => _eventHandlers;

--- a/lib/src/scoped_objects.dart
+++ b/lib/src/scoped_objects.dart
@@ -175,7 +175,7 @@ class ScopedObjects {
   /// [DisposableObject.dispose]
   Future<void> clear() async {
     _isClearing = true;
-    final values = pool.values;
+    final values = pool.values.toList();
     for (final v in values) {
       await v?._disposeOnParentClear();
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: iris_method_channel
 description: >-
   iris_method_channel is a method channel that communicate between C/C++(iris)
   and dart, which is used by Agora Flutter SDKs.
-version: 2.2.4
+version: 2.2.5
 homepage: https://www.agora.io
 repository: https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/tree/main
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: iris_method_channel
 description: >-
   iris_method_channel is a method channel that communicate between C/C++(iris)
   and dart, which is used by Agora Flutter SDKs.
-version: 2.2.3-ohos.223
+version: 2.2.4
 homepage: https://www.agora.io
 repository: https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/tree/main
 environment:

--- a/src/iris_event.cc
+++ b/src/iris_event.cc
@@ -202,7 +202,7 @@ std::unique_ptr<DartMessageHandlerManager> dartMessageHandlerManager_ = nullptr;
 int init_dart_api_times_ = 0;
 
 // Initialize `dart_api_dl.h`
-EXPORT intptr_t InitDartApiDL(void *data)
+EXPORT intptr_t Iris_InitDartApiDL(void *data)
 {
     std::lock_guard<std::mutex> lock(message_handler_mutex_);
     int ret = 0;
@@ -217,7 +217,7 @@ EXPORT intptr_t InitDartApiDL(void *data)
     return ret;
 }
 
-EXPORT void Dispose()
+EXPORT void Iris_Dispose()
 {
     std::lock_guard<std::mutex> lock(message_handler_mutex_);
     --init_dart_api_times_;
@@ -227,7 +227,7 @@ EXPORT void Dispose()
     }
 }
 
-EXPORT void OnEvent(EventParam *param)
+EXPORT void Iris_OnEvent(EventParam *param)
 {
     std::lock_guard<std::mutex> lock(message_handler_mutex_);
     if (dartMessageHandlerManager_)
@@ -236,7 +236,7 @@ EXPORT void OnEvent(EventParam *param)
     }
 }
 
-EXPORT void RegisterDartPort(Dart_Port send_port)
+EXPORT void Iris_RegisterDartPort(Dart_Port send_port)
 {
     std::lock_guard<std::mutex> lock(message_handler_mutex_);
     if (dartMessageHandlerManager_)
@@ -245,7 +245,7 @@ EXPORT void RegisterDartPort(Dart_Port send_port)
     }
 }
 
-EXPORT void UnregisterDartPort(Dart_Port send_port)
+EXPORT void Iris_UnregisterDartPort(Dart_Port send_port)
 {
     std::lock_guard<std::mutex> lock(message_handler_mutex_);
     if (dartMessageHandlerManager_)

--- a/src/iris_event.h
+++ b/src/iris_event.h
@@ -27,15 +27,15 @@ extern "C"
     } EventParam;
 
     // Initialize `dart_api_dl.h`
-    EXPORT intptr_t InitDartApiDL(void *data);
+    EXPORT intptr_t Iris_InitDartApiDL(void *data);
 
-    EXPORT void Dispose();
+    EXPORT void Iris_Dispose();
 
-    EXPORT void OnEvent(EventParam *param);
+    EXPORT void Iris_OnEvent(EventParam *param);
 
-    EXPORT void RegisterDartPort(Dart_Port send_port);
+    EXPORT void Iris_RegisterDartPort(Dart_Port send_port);
 
-    EXPORT void UnregisterDartPort(Dart_Port send_port);
+    EXPORT void Iris_UnregisterDartPort(Dart_Port send_port);
 
 #ifdef __cplusplus
 }

--- a/test/repro_concurrent_modification_test.dart
+++ b/test/repro_concurrent_modification_test.dart
@@ -1,0 +1,123 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:iris_method_channel/iris_method_channel.dart';
+
+class _FakePlatformBindingsDelegate extends PlatformBindingsDelegateInterface {
+  @override
+  int callApi(IrisMethodCall methodCall, IrisApiEngineHandle apiEnginePtr, IrisApiParamHandle param) => 0;
+
+  @override
+  Future<CallApiResult> callApiAsync(IrisMethodCall methodCall, IrisApiEngineHandle apiEnginePtr, IrisApiParamHandle param) async => CallApiResult(data: {}, irisReturnCode: 0);
+
+  @override
+  CreateApiEngineResult createApiEngine(List<InitilizationArgProvider> args) => CreateApiEngineResult(IrisApiEngineHandle(0));
+
+  @override
+  IrisEventHandlerHandle createIrisEventHandler(IrisCEventHandlerHandle eventHandler) => IrisEventHandlerHandle(0);
+
+  @override
+  void destroyIrisEventHandler(IrisEventHandlerHandle handler) {}
+
+  @override
+  void destroyNativeApiEngine(IrisApiEngineHandle apiEnginePtr) {}
+
+  @override
+  void initialize() {}
+}
+
+class _FakePlatformBindingsProvider extends PlatformBindingsProvider {
+  @override
+  PlatformBindingsDelegateInterface provideNativeBindingDelegate() {
+    return _FakePlatformBindingsDelegate();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  
+  test('ConcurrentModificationError should not be thrown when adding/removing handlers during event dispatch', () async {
+    final provider = _FakePlatformBindingsProvider();
+    final irisMethodChannel = IrisMethodChannel(provider);
+    
+    // Logic Tester that mimics the FIXED IrisMethodChannel event loop
+    void simulateEventLoop(IrisMethodChannel channel, IrisEventMessage message) {
+      bool handled = false;
+      // We use the same snapshotting logic as in the fixed IrisMethodChannel
+      for (final sub in channel.scopedEventHandlers.values) {
+        final scopedObjects = sub as DisposableScopedObjects;
+        for (final es in scopedObjects.values) {
+          final EventHandlerHolder eh = es as EventHandlerHolder;
+          final handlersSnapshot = eh.getEventHandlers();
+
+          for (final e in handlersSnapshot.toList()) {
+            if (!eh.getEventHandlers().contains(e)) {
+              continue;
+            }
+            if (e.handleEvent(message.event, message.data, message.buffers)) {
+              handled = true;
+            }
+          }
+
+          if (handled) {
+            break;
+          }
+        }
+        if (handled) {
+          break;
+        }
+      }
+    }
+
+    const key = TypedScopedKey(Object);
+    final subScopedObjects = irisMethodChannel.scopedEventHandlers.putIfAbsent(key, () => DisposableScopedObjects()) as DisposableScopedObjects;
+    final eventKey = EventHandlerHolderKey(registerName: 'test_event', unregisterName: 'test_event');
+    final holder = subScopedObjects.putIfAbsent(eventKey, () => EventHandlerHolder(key: eventKey)) as EventHandlerHolder;
+
+    // 1. Test removing self during event handling
+    late EventLoopEventHandler handlerToRemove;
+    bool handlerCalled = false;
+    
+    handlerToRemove = _TestEventHandler((eventName, eventData, buffers) {
+      handlerCalled = true;
+      holder.removeEventHandler(handlerToRemove);
+      return true;
+    });
+
+    holder.addEventHandler(handlerToRemove);
+
+    // This should NOT throw error
+    simulateEventLoop(irisMethodChannel, const IrisEventMessage('test_event', '{}', []));
+    expect(handlerCalled, true);
+    expect(holder.getEventHandlers().length, 0);
+
+    // 2. Test adding another handler during event handling
+    bool firstHandlerCalled = false;
+    final firstHandler = _TestEventHandler((eventName, eventData, buffers) {
+      firstHandlerCalled = true;
+      holder.addEventHandler(_TestEventHandler((_, __, ___) => true));
+      return false;
+    });
+
+    holder.addEventHandler(firstHandler);
+
+    simulateEventLoop(irisMethodChannel, const IrisEventMessage('test_event', '{}', []));
+    expect(firstHandlerCalled, true);
+    expect(holder.getEventHandlers().length, 2); // 1 (firstHandler) + 1 (added handler)
+  });
+}
+
+typedef HandleEventCallback = bool Function(String eventName, String eventData, List<Uint8List> buffers);
+
+class _TestEventHandler extends EventLoopEventHandler with ScopedDisposableObjectMixin implements DisposableObject {
+  _TestEventHandler(this.callback);
+  final HandleEventCallback callback;
+
+  @override
+  bool handleEventInternal(String eventName, String eventData, List<Uint8List> buffers) {
+    return callback(eventName, eventData, buffers);
+  }
+
+  @override
+  Future<void> dispose() async {}
+}


### PR DESCRIPTION
## Summary
- sync the prefixed Iris native symbols from main
- sync the concurrent event-dispatch fix and its regression test
- advance the OHOS branch release metadata to 2.2.5 while preserving the OHOS platform scaffold and shared-library loading

## Validation
- [x] Flutter 3.35.8-ohos-1.0.1: `flutter test` (47 tests)
- [x] Flutter 3.24.5: `flutter test` (47 tests)
- [x] `flutter build hap --debug --no-codesign`
- [x] `flutter build hap --release --no-codesign`
- [x] verified the arm64 `libiris_method_channel.so` payload and all five `Iris_*` exports

## Notes
- the 2.2.4 cherry-pick had one expected version-line conflict between `2.2.3-ohos.223` and `2.2.4`; it was resolved to follow the main release sequence, ending at `2.2.5`
- do not publish this branch independently as `2.2.5` without a separate version/tag decision; the existing `2.2.5` tag points to main and that version is already part of the main release line