### PR TITLE
feat(web): migrate web bindings to dart:js_interop for WebAssembly (dart2wasm) support

### DIFF
--- a/lib/src/platform/io/bindings/native_iris_api_common_bindings.dart
+++ b/lib/src/platform/io/bindings/native_iris_api_common_bindings.dart
@@ -2,7 +2,7 @@
 
 import 'dart:ffi' as ffi;
 
-class ApiParam extends ffi.Struct {
+final class ApiParam extends ffi.Struct {
   external ffi.Pointer<ffi.Int8> event;
 
   external ffi.Pointer<ffi.Int8> data;
@@ -22,14 +22,14 @@ class ApiParam extends ffi.Struct {
 
 // typedef IrisEventHandlerHandle = ffi.Pointer<ffi.Void>;
 
-class IrisCEventHandler extends ffi.Struct {
+final class IrisCEventHandler extends ffi.Struct {
   external Func_Event OnEvent;
 }
 
 typedef Func_Event = ffi
     .Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<EventParam>)>>;
 
-class EventParam extends ffi.Struct {
+final class EventParam extends ffi.Struct {
   external ffi.Pointer<ffi.Int8> event;
 
   external ffi.Pointer<ffi.Int8> data;

--- a/lib/src/platform/io/bindings/native_iris_event_bindings.dart
+++ b/lib/src/platform/io/bindings/native_iris_event_bindings.dart
@@ -176,7 +176,7 @@ class _SymbolAddresses {
               ffi.Uint32)>> get OnEventExLegacy => _library._OnEventExLegacyPtr;
 }
 
-class EventParam extends ffi.Struct {
+final class EventParam extends ffi.Struct {
   external ffi.Pointer<ffi.Int8> event;
 
   external ffi.Pointer<ffi.Int8> data;

--- a/lib/src/platform/iris_method_channel_internal.dart
+++ b/lib/src/platform/iris_method_channel_internal.dart
@@ -1,3 +1,3 @@
 export 'iris_method_channel_internal_expect.dart'
     if (dart.library.io) 'iris_method_channel_internal_actual_io.dart'
-    if (dart.library.js) 'iris_method_channel_internal_actual_web.dart';
+    if (dart.library.js_interop) 'iris_method_channel_internal_actual_web.dart';

--- a/lib/src/platform/utils.dart
+++ b/lib/src/platform/utils.dart
@@ -1,3 +1,3 @@
 export 'package:iris_method_channel/src/platform/utils_expect.dart'
     if (dart.library.io) 'io/utils_actual_io.dart'
-    if (dart.library.js) 'web/utils_actual_web.dart';
+    if (dart.library.js_interop) 'web/utils_actual_web.dart';

--- a/lib/src/platform/web/bindings/iris_api_common_bindings_js.dart
+++ b/lib/src/platform/web/bindings/iris_api_common_bindings_js.dart
@@ -1,30 +1,29 @@
-@JS()
-library iris_web;
-
 import 'dart:convert';
-import 'dart:typed_data';
+import 'dart:js_interop';
 
 import 'package:iris_method_channel/src/platform/iris_event_interface.dart';
 import 'package:iris_method_channel/src/platform/iris_method_channel_interface.dart';
-import 'package:js/js.dart';
 
 // ignore_for_file: public_member_api_docs, non_constant_identifier_names
 
 // NOTE:
-// For compatibility to dart sdk >= 2.12, we only use the feature that are
-// supported in `js: 0.6.3` at this time
+// These bindings use `dart:js_interop` (instead of the legacy `package:js`)
+// so that they work under both dart2js and dart2wasm. Under dart2wasm the
+// legacy `dart.library.js` conditional imports are false and Dart `List`s are
+// not JS arrays, so all array-typed members are `JSArray` here and callers
+// must convert with `.toJS` / `.toDart`.
 
 @JS('IrisCore.EventParam')
-@anonymous
-class EventParam {
-  // Must have an unnamed factory constructor with named arguments.
+extension type EventParam._(JSObject _) implements JSObject {
+  // An external factory with only named arguments creates a JS object
+  // literal (the `dart:js_interop` equivalent of `@anonymous`).
   external factory EventParam({
     String event,
     String data,
     int data_size,
     String result,
-    List<Object> buffer,
-    List<int> length,
+    JSArray<JSAny?> buffer,
+    JSArray<JSNumber> length,
     int buffer_count,
   });
 
@@ -32,21 +31,22 @@ class EventParam {
   external String get data;
   external int get data_size;
   external String get result;
-  external List<Object> get buffer;
-  external List<int> get length;
+  external JSArray<JSAny?> get buffer;
+  external JSArray<JSNumber> get length;
   external int get buffer_count;
 }
 
 IrisEventMessage toIrisEventMessage(EventParam param) {
-  return IrisEventMessage(
-      param.event, param.data, List<Uint8List>.from(param.buffer));
+  final buffers = param.buffer.toDart
+      .map((e) => (e! as JSUint8Array).toDart)
+      .toList(growable: false);
+  return IrisEventMessage(param.event, param.data, buffers);
 }
 
 typedef ApiParam = EventParam;
 
 @JS('IrisCore.CallIrisApiResult')
-@anonymous
-class CallIrisApiResult {
+extension type CallIrisApiResult._(JSObject _) implements JSObject {
   external factory CallIrisApiResult({
     int code,
     String data,
@@ -64,12 +64,10 @@ extension CallIrisApiResultExt on CallIrisApiResult {
 }
 
 @JS('IrisCore.IrisEventHandler')
-@anonymous
-class IrisEventHandler {}
+extension type IrisEventHandler._(JSObject _) implements JSObject {}
 
 @JS('IrisCore.IrisApiEngine')
-@anonymous
-class IrisApiEngine {}
+extension type IrisApiEngine._(JSObject _) implements JSObject {}
 
 @JS('IrisCore.createIrisApiEngine')
 external IrisApiEngine createIrisApiEngine();
@@ -77,10 +75,12 @@ external IrisApiEngine createIrisApiEngine();
 @JS('IrisCore.disposeIrisApiEngine')
 external int disposeIrisApiEngine(IrisApiEngine engine_ptr);
 
+/// `IrisCore.callIrisApi` returns a `Promise<CallIrisApiResult>` on web.
 @JS('IrisCore.callIrisApi')
-external int callIrisApi(IrisApiEngine engine_ptr, ApiParam apiParam);
+external JSPromise<CallIrisApiResult> callIrisApi(
+    IrisApiEngine engine_ptr, ApiParam apiParam);
 
-typedef IrisEventHandlerFuncJS = void Function(EventParam param);
+typedef IrisEventHandlerFuncJS = JSFunction;
 typedef IrisCEventHandler = IrisEventHandlerFuncJS;
 
 @JS('IrisCore.createIrisEventHandler')

--- a/lib/src/platform/web/iris_method_channel_internal_web.dart
+++ b/lib/src/platform/web/iris_method_channel_internal_web.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:js';
+import 'dart:js_interop';
 import 'package:flutter/foundation.dart' show VoidCallback;
 import 'package:iris_method_channel/iris_method_channel.dart';
 
@@ -108,7 +108,7 @@ class IrisMethodChannelInternalWeb implements IrisMethodChannelInternal {
         _platformBindingsDelegate!.createApiEngine(args);
     _irisApiEngine = createApiEngineResult.apiEnginePtr;
 
-    _irisEventHandlerFuncJS = allowInterop(_onEventFromJS);
+    _irisEventHandlerFuncJS = _onEventFromJS.toJS;
     _irisEventHandlerHandle = _platformBindingsDelegate!.createIrisEventHandler(
         IrisCEventHandlerHandle(_irisEventHandlerFuncJS!));
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,8 +6,10 @@ version: 2.2.5
 homepage: https://www.agora.io
 repository: https://github.com/AgoraIO-Extensions/iris_method_channel_flutter/tree/main
 environment:
-  sdk: '>=2.14.0 <4.0.0'
-  flutter: '>=2.0.0'
+  # dart:js_interop extension types (wasm-compatible web bindings) require
+  # Dart >= 3.3.
+  sdk: '>=3.3.0 <4.0.0'
+  flutter: '>=3.19.0'
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
## Problem

`flutter build web --wasm` builds that include this package compile successfully but break at runtime: the platform implementation is selected via

```dart
export 'iris_method_channel_internal_expect.dart'
    if (dart.library.io) 'iris_method_channel_internal_actual_io.dart'
    if (dart.library.js) 'iris_method_channel_internal_actual_web.dart';
```

and under dart2wasm **both** `dart.library.io` and `dart.library.js` are false (wasm exposes `dart.library.js_interop` instead), so the stub implementation is exported and `createAgoraRtcEngine()` in agora_rtc_engine throws `UnimplementedError: Unimplemented createPlatformBindingsProvider` before any API call runs. Because this is a silent wrong-import selection rather than a compile error, apps only discover it in production wasm builds.

## Changes

- Conditional imports in `iris_method_channel_internal.dart` and `utils.dart`: `dart.library.js` → `dart.library.js_interop`, which is true under **both** dart2js and dart2wasm, so a single web implementation serves both compilers (including the JS fallback that `--wasm` builds ship for non-wasmGC browsers).
- `lib/src/platform/web/bindings/iris_api_common_bindings_js.dart`: migrated from legacy `package:js` `@JS()`/`@anonymous` classes to `dart:js_interop` extension types (legacy `package:js`/`dart:js` are unavailable under dart2wasm):
  - array-typed members are now `JSArray` — under dart2wasm Dart `List`s are not JS arrays, so implicit passthrough no longer exists; callers convert with `.toJS`/`.toDart`.
  - `callIrisApi` is now typed `JSPromise<CallIrisApiResult>` (what `IrisCore.callIrisApi` actually returns) instead of `int` + a `dartify()` Promise cast, which does not work under dart2wasm.
  - `IrisCEventHandler` is now a `JSFunction` typedef; `iris_method_channel_internal_web.dart` uses `.toJS` instead of `allowInterop`.
- `pubspec.yaml`: SDK floor raised to `>=3.3.0` (required for `dart:js_interop` extension types). The language-version bump also requires the ffigen-generated `ffi.Struct` subclasses to be `final` (Dart 3 class modifiers) — io-only files, no behavior change.

## Breaking-change note

The exported web bindings surface (`iris_method_channel_bindings_web.dart`) changes shape (JS types instead of Dart lists/functions). Its consumer in agora_rtc_engine needs the matching one-file update to its web binding delegate — I will submit that companion PR to Agora-Flutter-SDK referencing this one. `test/platform/fake` still uses legacy interop and is untouched in this PR; happy to migrate it as well if you'd like.

## Testing

- `dart analyze lib` clean (errors/warnings).
- End-to-end smoke test in a production Flutter app (agora_rtc_engine 6.6.3 + iris-web-rtc 0.8.1, headless Chrome with fake media devices): under **both** the wasm and dart2js runtimes, `createAgoraRtcEngine` → `initialize` → `registerEventHandler` → `enableAudio` → `joinChannel` all succeed, and the JS→Dart event path delivers typed events (including the `buffer` marshalling in both directions). dart2js behavior is unchanged.