### PR TITLE
fix: retain Iris symbols in macOS SwiftPM Archive

### DIFF
--- a/macos/iris_method_channel/Package.swift
+++ b/macos/iris_method_channel/Package.swift
@@ -9,7 +9,11 @@ let package = Package(
         .macOS("10.14")
     ],
     products: [
-        .library(name: "iris-method-channel", targets: ["iris_method_channel"])
+        .library(
+            name: "iris-method-channel",
+            type: .dynamic,
+            targets: ["iris_method_channel"]
+        )
     ],
     dependencies: [],
     targets: [


### PR DESCRIPTION
## Summary
- Build the macOS SwiftPM product as a dynamic library, matching the iOS SwiftPM packaging.
- Keep `Iris_*` symbols visible in macOS Archive products for `DynamicLibrary.process()` lookup.

## Validation
- `swift package dump-package` confirms `iris-method-channel` is dynamic.
- `flutter test` passes: 47 tests.
- Full local Flutter macOS SPM generation is blocked by the worktree directory identity (`fix-spm-symbol-retain` vs `iris_method_channel`); GitHub Actions should provide the real Archive validation.

## Release
After merge, run the repository release workflow for `2.2.7`; this PR intentionally does not change `pubspec.yaml` or `CHANGELOG.md`.